### PR TITLE
Fix Exception on Authentication Txns

### DIFF
--- a/src/catalog/controller/payment/mastercard.php
+++ b/src/catalog/controller/payment/mastercard.php
@@ -640,9 +640,6 @@ class Mastercard extends \Opencart\System\Engine\Controller {
 				foreach ( $txns as $txn ) {
 					if ( isset( $txn['transaction']['authorizationCode'] ) ) {
 						$transaction['transaction']['authorizationCode'] = $txn['transaction']['authorizationCode'];
-					} elseif( 'PAYPAL' === $txn['transaction']['acquirer']['id'] ) {
-						$transaction['transaction']['id']        = $txn['transaction']['id'];
-						$transaction['transaction']['reference'] = $txn['transaction']['reference'];
 					} else {
 						$transaction['transaction']['id']        = $txn['transaction']['id'];
 						$transaction['transaction']['reference'] = $txn['transaction']['reference'];

--- a/src/catalog/controller/payment/mastercard.php
+++ b/src/catalog/controller/payment/mastercard.php
@@ -638,6 +638,9 @@ class Mastercard extends \Opencart\System\Engine\Controller {
             
             if( $txns ) {
 				foreach ( $txns as $txn ) {
+                    if ($txn['transaction']['type'] !== 'AUTHORIZATION' && $txn['transaction']['type'] !== 'PAYMENT') {
+                        continue;
+                    }
 					if ( isset( $txn['transaction']['authorizationCode'] ) ) {
 						$transaction['transaction']['authorizationCode'] = $txn['transaction']['authorizationCode'];
 					} else {


### PR DESCRIPTION
The code loops over transactions and checks if the acquirer ID is `PAYPAL`. However, if the transaction type is `Authentication`, it will not have the `acquirer` field, causing an exception. I noticed the code blocks executed in the `elseif` and `else` are the same, so the check is not effective.

The loop shouldn't be trying to extract data from non-authorization or purchase transactions anyways.